### PR TITLE
Add 3x new profile methods - plus a few tweaks

### DIFF
--- a/lib/Data/FormValidator/Constraints.pm
+++ b/lib/Data/FormValidator/Constraints.pm
@@ -412,11 +412,23 @@ sub FV_num_values_between {
         my $param = $dfv->get_current_constraint_field();
         my $value = $dfv->get_filtered_data()->{$param};
 
-        my $num_values = scalar @$value;
+		if (ref($value) eq 'ARRAY') {
+	        my $num_values = scalar @$value;
 
-        return ($num_values >= $min) && ($num_values <= $max) if ref $value eq 'ARRAY';
-        return 1 if $min == 0 && $max >= 2; # scalar, size could be 1
-        return 0;                           # scalar, size can't be 1
+	        return(
+	        	(
+	        		$num_values >= $min
+	        		&& $num_values <= $max
+	        	) ? 1 : 0
+	        );
+		} else {
+			if ($min <= 1 && $max >= 1) {
+				# Single value is allowed
+				return 1;
+			} else {
+				return 0;
+			}
+		}
     }
 }
 

--- a/lib/Data/FormValidator/Constraints/Upload.pm
+++ b/lib/Data/FormValidator/Constraints/Upload.pm
@@ -302,7 +302,10 @@ sub _get_upload_fh
     # we might not have something -seekable-.
     use IO::File;
 
-    if (ref $q->{$field} eq 'IO::File') {
+    # If we we already have an IO::File object, return it, otherwise create one.
+    require Scalar::Util;
+
+    if ( Scalar::Util::blessed($q->{$field}) && $q->{$field}->isa('IO::File') ) {
         return $q->{$field};
     }
     else {


### PR DESCRIPTION
This commit adds 3x new profile methods:

depedencies_regexp - Allow the setting of dependencies through a regexp like required, optional and constraints
dependent_optional - Allow the adding of optional values based upon other values - dependencies only adds required fields, this allows you to add optional values
dependent_require_some - Allow the adding of require_some groups based upon other values - e.g. you only require some of these values if this value is set

Plus a few small tweaks which have been languishing on my local copy for ages