### PR TITLE
Prevent installing README.pod to final install

### DIFF
--- a/INSTALL.SKIP
+++ b/INSTALL.SKIP
@@ -1,0 +1,1 @@
+\bREADME\.pod$


### PR DESCRIPTION
This fixes the final "make install" so that matching regexed files do
not get copied from blib/ to the OS

Previously, a cruft file could be found in `@INC` by performing:

    perldoc Data::README

Which would give you the README.pod of Data::FormValidator

This is a left-over artifact from the old days where this mechanism
was The Way to install .pod/.pm files, and is still heavily used this
way for .xs files.