### PR TITLE
fixed retrieving params when using CGI::FormBuilder as data input

### DIFF
--- a/lib/Data/FormValidator/Results.pm
+++ b/lib/Data/FormValidator/Results.pm
@@ -1165,6 +1165,10 @@ sub _get_input_as_hash {
             if ($data->isa('CGI::Simple')) {
                 @v = $data->upload($k) || $data->param($k);
             }
+            # CGI::FormBuilder doesn't support returning field value from `multi_param`
+            elsif ($data->isa('CGI::FormBuilder')) {
+                @v = $data->param($k);
+            }
             else {
                 # insecure
                 @v = $data->multi_param($k);

--- a/t/16_cgi-formbuilder_object.t
+++ b/t/16_cgi-formbuilder_object.t
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use lib ( '.', '../t' );
+use Test::More;
+use Data::FormValidator;
+
+# This script tests whether a CGI::FormBuilder.pm object can be used to provide the input data
+# cngarrison - 2021-09-14
+
+eval { require CGI::FormBuilder;CGI::FormBuilder->VERSION(3.08); };
+plan skip_all => 'CGI::FormBuilder 3.08 or higher not found' if $@;
+
+my $input_profile = {
+	required           => ['my_zipcode_field'],
+	constraint_methods => {
+		my_zipcode_field => qr/^[A-Za-z]+\ [A-Za-z]+$/,
+	}
+};
+
+my $validator = new Data::FormValidator( { default => $input_profile } );
+
+my $fb;
+eval {
+	$fb = CGI::FormBuilder->new(
+		fields   => [qw(my_zipcode_field)],
+		values   => { my_zipcode_field => 'big brown' },
+		#validate => $validator,
+	);
+};
+ok( not $@ );
+
+my ( $valids, $missings, $invalids, $unknowns );
+eval {
+  ( $valids, $missings, $invalids, $unknowns ) =
+    $validator->validate( $fb, 'default' );
+};
+
+is( $valids->{my_zipcode_field}, 'big brown' );
+done_testing;


### PR DESCRIPTION
`Data::FormValidator::Results-> _get_input_as_hash ` changed from calling `$data->param($k)` to `$data->multi_param($k)`. That broke using `CGI::FormBuilder` as data input since it only supports `multi_param` via `AUTOLOAD` and instead of returning the field value, it returns the internal field attribute (object).  That breaks the `__INPUT_DATA` in `Data::FormValidator::Results`.

This change simply adds another `isa` check for the data input, and calls `param` instead of `multi-param`. It's likely more accurate to call `field` method instead of `param` but I opted for change that reinstated old behaviour. 